### PR TITLE
Fix setup.py for CPU-only installs.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -175,6 +175,9 @@ if torch.cuda.is_available() and os.path.exists(cuda_source):
         raise RuntimeError("CUDA headers not found")
 else:
     print("Building CPU-only extension...")
+    cuda_include_dirs = get_cuda_include_dirs()
+    if cuda_include_dirs:
+        base_include_dirs.extend(cuda_include_dirs)
     extension = CppExtension(
         name='sparse_transformers.sparse_transformers',
         sources=[cpp_source],


### PR DESCRIPTION
## Description
Fixes installation on CPU-only systems by adding cuda_include_dirs to base_include_dirs in setup.py to avoid installation of cpp extensions failing.