### PR TITLE
Fix train

### DIFF
--- a/src/trainer.py
+++ b/src/trainer.py
@@ -350,7 +350,6 @@ class LayerwisePredictorTrainer:
         save_interval: int = 1000,
         resume_from_checkpoint: bool = False,
         checkpoint_path: Optional[str] = None,
-        restart_if_missing = False
     ) -> FastLoRAProjection:
         """Train a single layer's predictor.
 
@@ -424,19 +423,18 @@ class LayerwisePredictorTrainer:
                     logger.info(
                         f"Resumed training from step {global_step}, epoch {start_epoch}"
                     )
-                except Exception as e:
-                    if restart_if_missing:
-                        logger.warning(
-                            f"Failed to load checkpoint: {e}. Starting fresh training."
-                        )
-                        global_step = 0
-                        start_epoch = 0
-                        #best_f1 = 0.0
-                    else:
-                        logger.warning(
-                            f"Failed to load checkpoint: {e}. Skipping training."
-                        )
-                        return None
+                except FileNotFoundError as e:
+                    logger.warning(
+                        f"Failed to load checkpoint: {e}. Starting fresh training."
+                    )
+                    global_step = 0
+                    start_epoch = 0
+                    #best_f1 = 0.0
+                except AssertionError as e:
+                    logger.warning(
+                        f"Failed to load checkpoint: {e}. Skipping training."
+                    )
+                    return None
             else:
                 logger.info("No checkpoint found. Starting fresh training.")
 
@@ -796,7 +794,6 @@ class MultiLayerPredictorTrainer:
         save_interval: int = 1000,
         resume_from_checkpoint: bool = False,
         checkpoint_path: Optional[str] = None,
-        restart_if_missing: bool = False,
         load_best_only: bool = False,
         seed: int = 42,
     ):
@@ -857,8 +854,7 @@ class MultiLayerPredictorTrainer:
                     save_dir=save_dir,
                     save_interval=save_interval,
                     resume_from_checkpoint=resume_from_checkpoint,
-                    checkpoint_path=checkpoint_path,
-                    restart_if_missing=restart_if_missing
+                    checkpoint_path=checkpoint_path
                 )
             else:
                 # Train each layer with each LoRA size (hyperparameter grid)
@@ -878,8 +874,7 @@ class MultiLayerPredictorTrainer:
                         save_dir=save_dir,
                         save_interval=save_interval,
                         resume_from_checkpoint=resume_from_checkpoint,
-                        checkpoint_path=checkpoint_path,
-                        restart_if_missing=restart_if_missing
+                        checkpoint_path=checkpoint_path
                     )
 
         logger.info(
@@ -900,8 +895,7 @@ class MultiLayerPredictorTrainer:
         save_dir: Optional[str] = None,
         save_interval: int = 1000,
         resume_from_checkpoint: bool = False,
-        checkpoint_path: Optional[str] = None,
-        restart_if_missing: bool = False,
+        checkpoint_path: Optional[str] = None
     ):
         final_checkpoint = (
             f"final_predictor_layer_{layer_idx}_lora_{lora_pct:.1f}pct"
@@ -971,8 +965,7 @@ class MultiLayerPredictorTrainer:
             save_dir=save_dir,
             save_interval=save_interval,
             resume_from_checkpoint=resume_from_checkpoint,
-            checkpoint_path=layer_checkpoint_path,
-            restart_if_missing=restart_if_missing
+            checkpoint_path=layer_checkpoint_path
         )
 
         logger.info(

--- a/train.py
+++ b/train.py
@@ -70,6 +70,18 @@ Usage:
         --learning_rate 1e-5 \
         --resume_from_checkpoint \
         --checkpoint_path ./trained_predictors/checkpoint_layer_0_step_5000.pt
+
+    # Resume only from best-performing lora size per layer
+    python train.py \
+        --config meta-llama/Llama-2-7b-hf \
+        --dataset_dir ./data/c4 \
+        --output_dir ./trained_predictors \
+        --layer_indices 0 \
+        --batch_size 32 \
+        --num_epochs 10 \
+        --learning_rate 1e-5 \
+        --resume_from_checkpoint \
+        --load_best_only
 """
 
 import argparse
@@ -108,7 +120,6 @@ def main():
     parser.add_argument("--checkpoint_save_interval", type=int, default=20000, help="Save checkpoint every N steps")
     parser.add_argument("--resume_from_checkpoint", action="store_true", help="Resume training from the latest checkpoint")
     parser.add_argument("--checkpoint_path", type=str, default=None, help="Specific checkpoint path to resume from (optional)")
-    parser.add_argument("--restart_if_missing", action="store_true", help="Restart training from scratch if correct checkpoint not found.")
     parser.add_argument("--load_best_only", action="store_true", help="Resume training only from best performing lora size for each layer.")
     parser.add_argument("--seed", type=int, default=42, help="Random seed")
     parser.add_argument("--use_wandb", action="store_true", help="Use Weights & Biases logging")
@@ -182,7 +193,6 @@ def main():
         save_dir=args.output_dir,
         save_interval=args.checkpoint_save_interval,
         resume_from_checkpoint=args.resume_from_checkpoint,
-        restart_if_missing=args.restart_if_missing,
         load_best_only= args.load_best_only,
         checkpoint_path=args.checkpoint_path,
         seed=args.seed

--- a/train.py
+++ b/train.py
@@ -109,6 +109,7 @@ def main():
     parser.add_argument("--resume_from_checkpoint", action="store_true", help="Resume training from the latest checkpoint")
     parser.add_argument("--checkpoint_path", type=str, default=None, help="Specific checkpoint path to resume from (optional)")
     parser.add_argument("--restart_if_missing", action="store_true", help="Restart training from scratch if correct checkpoint not found.")
+    parser.add_argument("--load_from_best", action="store_true", help="Resume training only from best performing lora size for each layer.")
     parser.add_argument("--seed", type=int, default=42, help="Random seed")
     parser.add_argument("--use_wandb", action="store_true", help="Use Weights & Biases logging")
     parser.add_argument("--wandb_project", type=str, default="llama-skip-predictors", help="W&B project name")
@@ -181,6 +182,8 @@ def main():
         save_dir=args.output_dir,
         save_interval=args.checkpoint_save_interval,
         resume_from_checkpoint=args.resume_from_checkpoint,
+        restart_if_missing=args.restart_if_missing,
+        load_best_only= args.load_best_only,
         checkpoint_path=args.checkpoint_path,
         seed=args.seed
     )

--- a/train.py
+++ b/train.py
@@ -108,6 +108,7 @@ def main():
     parser.add_argument("--checkpoint_save_interval", type=int, default=20000, help="Save checkpoint every N steps")
     parser.add_argument("--resume_from_checkpoint", action="store_true", help="Resume training from the latest checkpoint")
     parser.add_argument("--checkpoint_path", type=str, default=None, help="Specific checkpoint path to resume from (optional)")
+    parser.add_argument("--restart_if_missing", action="store_true", help="Restart training from scratch if correct checkpoint not found.")
     parser.add_argument("--seed", type=int, default=42, help="Random seed")
     parser.add_argument("--use_wandb", action="store_true", help="Use Weights & Biases logging")
     parser.add_argument("--wandb_project", type=str, default="llama-skip-predictors", help="W&B project name")

--- a/train.py
+++ b/train.py
@@ -109,7 +109,7 @@ def main():
     parser.add_argument("--resume_from_checkpoint", action="store_true", help="Resume training from the latest checkpoint")
     parser.add_argument("--checkpoint_path", type=str, default=None, help="Specific checkpoint path to resume from (optional)")
     parser.add_argument("--restart_if_missing", action="store_true", help="Restart training from scratch if correct checkpoint not found.")
-    parser.add_argument("--load_from_best", action="store_true", help="Resume training only from best performing lora size for each layer.")
+    parser.add_argument("--load_best_only", action="store_true", help="Resume training only from best performing lora size for each layer.")
     parser.add_argument("--seed", type=int, default=42, help="Random seed")
     parser.add_argument("--use_wandb", action="store_true", help="Use Weights & Biases logging")
     parser.add_argument("--wandb_project", type=str, default="llama-skip-predictors", help="W&B project name")


### PR DESCRIPTION
## Description
Refactors training code to address current issues with all lora sizes being saved/logged to the same locations.

- Logs all LoRA predictors to separate records in wandb
- Saves stepwise checkpoints only for the currently-training lora size. When resuming, all lora sizes for which a final end-of-training checkpoint has been saved are skipped. Otherwise, checkpoints are loaded for the current lora size only if the stepwise checkpoint matches that lora size. If not, either the training is restarted or that lora size is skipped, depending on the arguments passed
- A KV store is added to store the best f1 score for each layer among all lora sizes. A single best model for each layer is saved based on the highest f1 score. 
- A flag is added to optionally resume training each layer only from the lora size with the best performance

TODO:
- The KV store is currently simply a .pt dump. This should be replaced with a threadsafe KV store (e.g. LMDB)