### PR TITLE
Fix LayerAdaptiveDataset to work with load_full_dataset

### DIFF
--- a/src/trainer.py
+++ b/src/trainer.py
@@ -239,6 +239,8 @@ class StreamingSparsityDataset(TorchDataset):
             }
         
     def set_layer_idx(self, layer_idx):
+        if layer_idx == self.layer_idx:
+            return
         self.layer_idx = layer_idx
         if self.load_full_dataset:
             logger.info("Layer index changed with load_full_dataset=True. Reloading full dataset for new layer index...")


### PR DESCRIPTION
Fixes LayerAdaptiveDataset to properly reload the full dataset for the new layer when the layer index is changed with load_full_dataset=True. Previously, the data was not reloaded, and the data from the first layer would be used to train all predictors for that run.
